### PR TITLE
Add OARS, <releases>, and 19.08 runtime

### DIFF
--- a/Ri-li.appdata.xml
+++ b/Ri-li.appdata.xml
@@ -26,4 +26,8 @@
     <screenshot>http://ri-li.sourceforge.net/images/screenshot1.jpg</screenshot>
   </screenshots>
   <updatecontact>jwrdegoede_at_fedoraproject.org</updatecontact>
+  <releases>
+    <release version="2.0.1" date="2007-11-07"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
 </component>

--- a/net.sourceforge.Ri-li.json
+++ b/net.sourceforge.Ri-li.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.sourceforge.Ri-li",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",


### PR DESCRIPTION
This will have the side-effect of rebuilding the app, which will fix #3. Also fixes #1 but I would like to quote from the commit message:

I am actually not sure this OARS data is right. After you complete a
level, the game shows you a random article from the UN's Universal
Declaration of Human Rights. (They're distributed as images, not text,
and in the tarball we're using here they're further packed into some
archive format I don't recognise.)

![Capture d’écran de 2020-02-19 15-20-45](https://user-images.githubusercontent.com/86760/74859426-e992a100-533e-11ea-9daf-81f0d5011259.png)

If, like me, you need to refresh your memory, the Declaration is here:
https://www.un.org/en/universal-declaration-human-rights/

Article 4 is:

> No one shall be held in slavery or servitude; slavery and the slave
> trade shall be prohibited in all their forms.

This is arguably a reference to historical slavery. Should this gain a
violence-slavery: mild tag? Probably yes, but this would cause
appstream-glib to assign this game a minimum age of 13. It's been a long
time since I was 13, but I think this game is more suitable for a rather
younger audience…

I've left out the tag for now.